### PR TITLE
Add to ingore aria- generated attrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ The options wiil be predefined:
 
 ```js
 {
-    ignoreAttributes: ['id', 'for'],
+    ignoreAttributes: ['id', 'for', 'aria-labelledby', 'aria-describedby'],
     compareAttributesAsJSON: [
         'data-bem',
         { name: 'onclick', isFunction: true },

--- a/README.ru.md
+++ b/README.ru.md
@@ -229,7 +229,7 @@ var HtmlDiffer = require('html-differ').HtmlDiffer,
 
 ```js
 {
-    ignoreAttributes: ['id', 'for'],
+    ignoreAttributes: ['id', 'for', 'aria-labelledby', 'aria-describedby'],
     compareAttributesAsJSON: [
         'data-bem',
         { name: 'onclick', isFunction: true },

--- a/lib/utils/defaults.js
+++ b/lib/utils/defaults.js
@@ -15,7 +15,8 @@ var _ = require('lodash');
     if (typeof options === 'string') {
         if (options === 'bem') {
             options = {
-                ignoreAttributes: ['id', 'for'],
+                // ignore generated attributes
+                ignoreAttributes: ['id', 'for', 'aria-labelledby', 'aria-describedby'],
                 compareAttributesAsJSON: [
                     'data-bem',
                     { name: 'onclick', isFunction: true },


### PR DESCRIPTION
In BEMHTML and BH these attributes also automatically generate (by timestamp):
http://www.w3.org/WAI/PF/aria/states_and_properties#aria-labelledby
http://www.w3.org/WAI/PF/aria/states_and_properties#aria-describedby
As generation time is different from each generation process, we need to ignore these attributes.
