### PR TITLE
Upgrade to vow-fs@0.3.6 to get rid of the node-uuid deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "diff": "1.0.8",
     "lodash": "2.4.1",
     "parse5": "1.1.3",
-    "vow": "0.4.3",
-    "vow-fs": "0.3.1"
+    "vow": "0.4.13",
+    "vow-fs": "0.3.6"
   },
   "devDependencies": {
     "mocha": "1.18.2",


### PR DESCRIPTION
And also update `vow` to get it up to date with `vow-fs`.
https://github.com/dfilatov/vow-fs/blob/master/package.json#L18